### PR TITLE
Fix import PixelMessage from typings/events.d.ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Fixed
+- Fix import PixelMessage from typings/events.d.ts

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -1,5 +1,7 @@
 import { canUseDOM } from 'vtex.render-runtime'
 
+import { PixelMessage } from './typings/events'
+
 export function handleEvents(e: PixelMessage) {
   switch (e.data.eventName) {
     case 'vtex:pageView': {


### PR DESCRIPTION
import interface: 'PixelMessage' from typings/events.d.ts to avoid: `Typescript error' on the default pixel app template.

TS2304: Cannot find name 'PixelMessage'.

I can't edit VTEX IO CI/CD Bot message,   so please select: 
 [*]  Patch

And there is another pull request to include the docs builder.

Regards.
